### PR TITLE
Open projects larger than 30,000 files

### DIFF
--- a/src/filesystem/FileSystemEntry.js
+++ b/src/filesystem/FileSystemEntry.js
@@ -66,7 +66,7 @@ define(function (require, exports, module) {
         WatchedRoot     = require("filesystem/WatchedRoot");
 
     var VISIT_DEFAULT_MAX_DEPTH = 100,
-        VISIT_DEFAULT_MAX_ENTRIES = 30000;
+        VISIT_DEFAULT_MAX_ENTRIES = 200000;
 
     /* Counter to give every entry a unique id */
     var nextId = 0;

--- a/src/nls/bg/strings.js
+++ b/src/nls/bg/strings.js
@@ -94,7 +94,7 @@ define({
 
     // ProjectManager max files error string
     "ERROR_MAX_FILES_TITLE"             : "Грешка при обработката на файловете",
-    "ERROR_MAX_FILES"                   : "Този проект има над 30 000 файла. Функционалностите, които работят с множество файлове може да бъдат изключени или да работят така, сякаш проектът е празен. <a href='https://github.com/brackets-cont/brackets/wiki/Large-Projects'>Прочете повече относно работата с големи проекти</a>.",
+    "ERROR_MAX_FILES"                   : "Този проект има над 20s0 000 файла. Функционалностите, които работят с множество файлове може да бъдат изключени или да работят така, сякаш проектът е празен. <a href='https://github.com/brackets-cont/brackets/wiki/Large-Projects'>Прочете повече относно работата с големи проекти</a>.",
 
     // Live Preview error strings
     "ERROR_LAUNCHING_BROWSER_TITLE"     : "Грешка при пускането на браузъра",

--- a/src/nls/bg/strings.js
+++ b/src/nls/bg/strings.js
@@ -94,7 +94,7 @@ define({
 
     // ProjectManager max files error string
     "ERROR_MAX_FILES_TITLE"             : "Грешка при обработката на файловете",
-    "ERROR_MAX_FILES"                   : "Този проект има над 20s0 000 файла. Функционалностите, които работят с множество файлове може да бъдат изключени или да работят така, сякаш проектът е празен. <a href='https://github.com/brackets-cont/brackets/wiki/Large-Projects'>Прочете повече относно работата с големи проекти</a>.",
+    "ERROR_MAX_FILES"                   : "Този проект има над 200 000 файла. Функционалностите, които работят с множество файлове може да бъдат изключени или да работят така, сякаш проектът е празен. <a href='https://github.com/brackets-cont/brackets/wiki/Large-Projects'>Прочете повече относно работата с големи проекти</a>.",
 
     // Live Preview error strings
     "ERROR_LAUNCHING_BROWSER_TITLE"     : "Грешка при пускането на браузъра",

--- a/src/nls/fa-ir/strings.js
+++ b/src/nls/fa-ir/strings.js
@@ -92,7 +92,7 @@ define({
 
     // ProjectManager max files error string
     "ERROR_MAX_FILES_TITLE"             : "خطا در فهرست بندی پرونده ها",
-    "ERROR_MAX_FILES"                   : "این پروژه شامل بیش از 30000 فایل است. امکانات که در فایل های چندگانه کار می کنند ممکن است غیرفعال و یا به عنوان پروژه خالی در نظر گرفته شوند. <a href='https://github.com/brackets-cont/brackets/wiki/Large-Projects'>اطلاعات بیشتر در مورد کار با پروژه های بزرگ</a>.",
+    "ERROR_MAX_FILES"                   : "این پروژه شامل بیش از 200000 فایل است. امکانات که در فایل های چندگانه کار می کنند ممکن است غیرفعال و یا به عنوان پروژه خالی در نظر گرفته شوند. <a href='https://github.com/brackets-cont/brackets/wiki/Large-Projects'>اطلاعات بیشتر در مورد کار با پروژه های بزرگ</a>.",
 
     // Live Preview error strings
     "ERROR_LAUNCHING_BROWSER_TITLE"     : "خطا در اجرای مرورگر",

--- a/src/nls/id/strings.js
+++ b/src/nls/id/strings.js
@@ -96,7 +96,7 @@ define({
 
     // ProjectManager max files error string
     "ERROR_MAX_FILES_TITLE"             : "Gagal Mengindeks File",
-    "ERROR_MAX_FILES"                   : "Proyek ini mempunyai lebih dari 30,000 file. Fitur yang beroperasi di beberapa file mungkin dinonaktifkan atau bersikap seolah-olah proyek kosong. <a href='https://github.com/brackets-cont/brackets/wiki/Large-Projects'>Baca selengkapnya tentang bekerja dengan proyek besar</a>.",
+    "ERROR_MAX_FILES"                   : "Proyek ini mempunyai lebih dari 200,000 file. Fitur yang beroperasi di beberapa file mungkin dinonaktifkan atau bersikap seolah-olah proyek kosong. <a href='https://github.com/brackets-cont/brackets/wiki/Large-Projects'>Baca selengkapnya tentang bekerja dengan proyek besar</a>.",
 
     // Live Preview error strings
     "ERROR_LAUNCHING_BROWSER_TITLE"     : "Gagal Menjalankan Peramban",

--- a/src/nls/ja/strings.js
+++ b/src/nls/ja/strings.js
@@ -100,7 +100,7 @@ define({
 
     // ProjectManager max files error string
 	"ERROR_MAX_FILES_TITLE": "ファイルのインデックス時にエラーが発生しました。",
-	"ERROR_MAX_FILES": "このプロジェクトには 30,000 個以上のファイルが含まれています。複数のファイルを操作する機能が無効になるか、プロジェクトが空であるかのように動作します。<a href='https://github.com/brackets-cont/brackets/wiki/Large-Projects'>大きいプロジェクトの操作方法の詳細を表示</a>。",
+	"ERROR_MAX_FILES": "このプロジェクトには 200,000 個以上のファイルが含まれています。複数のファイルを操作する機能が無効になるか、プロジェクトが空であるかのように動作します。<a href='https://github.com/brackets-cont/brackets/wiki/Large-Projects'>大きいプロジェクトの操作方法の詳細を表示</a>。",
 
     // Live Preview error strings
 	"ERROR_LAUNCHING_BROWSER_TITLE": "ブラウザーの起動時にエラーが発生しました。",

--- a/src/nls/lv/strings.js
+++ b/src/nls/lv/strings.js
@@ -94,7 +94,7 @@ define({
 
     // ProjectManager max files error string
     "ERROR_MAX_FILES_TITLE"             : "Kļūda, indeksējot datnes",
-    "ERROR_MAX_FILES"                   : "Šis projekts ietver vairāk nekā 30000 datņu. Funkcijas, kas darbojas vairākās datnēs, var tikt atspējotas vai darboties tā, it kā projekts būtu tukšs. <a href='https://github.com/brackets-cont/brackets/wiki/Large-Projects'> Lasīt vairāk par strādāšanu ar lieliem projektiem</a>.",
+    "ERROR_MAX_FILES"                   : "Šis projekts ietver vairāk nekā 200000 datņu. Funkcijas, kas darbojas vairākās datnēs, var tikt atspējotas vai darboties tā, it kā projekts būtu tukšs. <a href='https://github.com/brackets-cont/brackets/wiki/Large-Projects'> Lasīt vairāk par strādāšanu ar lieliem projektiem</a>.",
 
     // Live Preview error strings
     "ERROR_LAUNCHING_BROWSER_TITLE"     : "Kļūda, palaižot pārlūku",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -100,7 +100,7 @@ define({
 
     // ProjectManager max files error string
     "ERROR_MAX_FILES_TITLE"             : "Error Indexing Files",
-    "ERROR_MAX_FILES"                   : "This project contains more than 30,000 files. Features that operate across multiple files may be disabled or behave as if the project is empty. <a href='https://github.com/brackets-cont/brackets/wiki/Large-Projects'>Read more about working with large projects</a>.",
+    "ERROR_MAX_FILES"                   : "This project contains more than 200,000 files. Features that operate across multiple files may be disabled or behave as if the project is empty. <a href='https://github.com/brackets-cont/brackets/wiki/Large-Projects'>Read more about working with large projects</a>.",
 
     // Live Preview error strings
     "ERROR_LAUNCHING_BROWSER_TITLE"     : "Error Launching Browser",

--- a/src/nls/uk/strings.js
+++ b/src/nls/uk/strings.js
@@ -92,7 +92,7 @@ define({
 
     // ProjectManager max files error string
     "ERROR_MAX_FILES_TITLE"                     : "Помилка індексації файлів",
-    "ERROR_MAX_FILES"                           : "Цей проект містить більше 30 000 файлів. Функції, що оперують кількома файлам можуть не працювати правильно або вимкнутись. <a href=\'https://github.com/brackets-cont/brackets/wiki/Large-Projects\'>Дізнайтесь більше про роботу програми під час відкриття великих проектів</a>.",
+    "ERROR_MAX_FILES"                           : "Цей проект містить більше 200 000 файлів. Функції, що оперують кількома файлам можуть не працювати правильно або вимкнутись. <a href=\'https://github.com/brackets-cont/brackets/wiki/Large-Projects\'>Дізнайтесь більше про роботу програми під час відкриття великих проектів</a>.",
 
     // Live Preview error strings
     "ERROR_LAUNCHING_BROWSER_TITLE"             : "Помилка запуску браузера",

--- a/src/nls/zh-tw/strings.js
+++ b/src/nls/zh-tw/strings.js
@@ -93,7 +93,7 @@ define({
 
     // ProjectManager max files error string
     "ERROR_MAX_FILES_TITLE"             : "無法建立檔案索引",
-    "ERROR_MAX_FILES"                   : "專案超過 30,000 個檔案。需要跨檔案執行的功能可能會被關閉或是變成跟專案內沒有任何檔案一樣。<a href='https://github.com/brackets-cont/brackets/wiki/Large-Projects'>了解怎麼處理大型專案</a>。",
+    "ERROR_MAX_FILES"                   : "專案超過 200,000 個檔案。需要跨檔案執行的功能可能會被關閉或是變成跟專案內沒有任何檔案一樣。<a href='https://github.com/brackets-cont/brackets/wiki/Large-Projects'>了解怎麼處理大型專案</a>。",
 
     // Live Preview error strings
     "ERROR_LAUNCHING_BROWSER_TITLE"     : "無法啟動瀏覽器",


### PR DESCRIPTION
* Increase Open files count to 200,000 from 30k
* Tested working in large projects with node modules
* Modern systems can handle files and folders much larger than 30k files than in 2012 when the original restriction was imposed.
* Find in files working on large projects

## Tests
* all unit tests passing without changes
* Find in files, js, language manager integration tests passing as expected