### PR TITLE
Fix php code-hints break

### DIFF
--- a/src/languageTools/LanguageClient/package.json
+++ b/src/languageTools/LanguageClient/package.json
@@ -14,6 +14,6 @@
   "author": "Adobe",
   "license": "MIT",
   "dependencies": {
-    "vscode-languageserver-protocol": "^3.14.1"
+    "vscode-languageserver-protocol": "3.14.1"
   }
 }


### PR DESCRIPTION
PHP extension was failing to load as it was depending on older versions of language server dependencies from npm. The language server code was defined in core, and the php extension was depending on private internal dependencies of the language server, which is in violation to the extension guidelines. 

Locked language server protocol to a working version as a stop-gap solution. We should consider refactoring to prevent this kind of dependencies between extensions and core.

https://github.com/brackets-cont/brackets/issues/50