### PR TITLE
Adding require alias for panelManager older extension compatibility 

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -39,7 +39,8 @@ require.config({
     map: {
         "*": {
             "thirdparty/CodeMirror2": "thirdparty/CodeMirror",
-            "thirdparty/preact"     : "preact-compat"
+            "thirdparty/preact"     : "preact-compat",
+            "view/PanelManager"     : "view/WorkspaceManager"  // For extension compatibility
         }
     }
 });


### PR DESCRIPTION
* Removed in assuming that no extensions were using it https://github.com/adobe/brackets/pull/11589
* Caused extension break https://github.com/jadbox/brackets-integrated-development
* and general extension issues later https://github.com/adobe/brackets/issues/11960

We just create an alias here as the Panel manager. Workspace manager is a superset of panel manager APIs

## Testing
* Brackets IDE extension now works with python
* Extension load that used old panel APIs working