### PR TITLE
Minor version bump to 2.0.1 to enable pre-release users to upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "Brackets",
-    "version": "2.0.0-0",
-    "apiVersion": "2.0.0",
+    "version": "2.0.1-0",
+    "apiVersion": "2.0.1",
     "homepage": "http://brackets.io",
     "issues": {
         "url": "http://github.com/brackets-cont/brackets/issues"

--- a/src/config.json
+++ b/src/config.json
@@ -25,8 +25,8 @@
         "notification_info_url"   : "https://getupdates.brackets.io/dev/notifications/<locale>.json"
     },
     "name": "Brackets",
-    "version": "2.0.0-0",
-    "apiVersion": "2.0.0",
+    "version": "2.0.1-0",
+    "apiVersion": "2.0.1",
     "homepage": "http://brackets.io",
     "issues": {
         "url": "http://github.com/brackets-cont/brackets/issues"

--- a/src/htmlContent/about-dialog.html
+++ b/src/htmlContent/about-dialog.html
@@ -23,6 +23,7 @@
                     <a href="https://github.com/ScanuNicco">scanunicco</a> ,
                     <a href="https://github.com/abose">Arun Bose</a> ,
                     <a href="https://github.com/charlypa">charly p abraham</a> ,
+                    <a href="https://github.com/tapanmanu">Tapan Manu</a> ,
                     <a href="https://github.com/lakshmianirudh">Lakshmi U G</a> ,
                     <a href="https://github.com/psdhanesh7">Dhanesh P S</a> ,
                     <a href="https://github.com/adrocknaphobia">Adam Lehman</a> ,


### PR DESCRIPTION
- Update brackets.io website contrib credits
- Minor version bump to 2.0.1 to enable pre-release users to upgrade
