### PR TITLE
Move remote file adapter to core and GitHub/Lab URL handling

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -15,14 +15,15 @@
         "twitter_name": "@BracketsCont",
         "contributors_url": "https://api.github.com/repos/brackets-cont/brackets/contributors?per_page={0}&page={1}",
         "extension_listing_url": "",
-        "extension_registry"         : "http://registry.brackets.s3.amazonaws.com/registry.json",
-        "extension_url"              : "http://registry.brackets.s3.amazonaws.com/{0}-{1}.zip",
+        "extension_registry": "http://registry.brackets.s3.amazonaws.com/registry.json",
+        "extension_url": "http://registry.brackets.s3.amazonaws.com/{0}-{1}.zip",
         "linting.enabled_by_default": true,
         "build_timestamp": "",
-        "googleAnalyticsID"     : "UA-212757129-1",
+        "googleAnalyticsID": "UA-212757129-1",
         "environment": "stage",
-        "update_info_url"         : "https://getupdates.brackets.io/dev/updates/<locale>.json",
-        "notification_info_url"   : "https://getupdates.brackets.io/dev/notifications/<locale>.json"
+        "update_info_url": "https://getupdates.brackets.io/dev/updates/<locale>.json",
+        "notification_info_url": "https://getupdates.brackets.io/dev/notifications/<locale>.json",
+        "buildtype": "dev"
     },
     "name": "Brackets",
     "version": "2.0.1-0",
@@ -90,7 +91,11 @@
         "prepush": "npm run eslint",
         "postinstall": "grunt install",
         "test": "grunt test",
-        "eslint": "grunt eslint"
+        "testJasmine": "grunt jasmine",
+        "testNode": "grunt jasmine-node",
+        "eslint": "grunt eslint",
+        "build": "grunt build",
+        "buildPreRelease": "grunt build-prerelease"
     },
     "licenses": [
         {

--- a/src/extensions/default/RemoteFileAdapter/main.js
+++ b/src/extensions/default/RemoteFileAdapter/main.js
@@ -1,12 +1,6 @@
 /*
- * Copyright (c) 2018 - present Adobe Systems Incorporated. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * Original work Copyright (c) 2018 - 2021 Adobe Systems Incorporated. All rights reserved.
  *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
@@ -21,11 +15,12 @@
  *
  */
 
+/*global URL*/
+
 define(function (require, exports, module) {
     "use strict";
 
     var AppInit         = brackets.getModule("utils/AppInit"),
-        FileSystem      = brackets.getModule("filesystem/FileSystem"),
         QuickOpen       = brackets.getModule("search/QuickOpen"),
         PathUtils       = brackets.getModule("thirdparty/path-utils/path-utils"),
         CommandManager  = brackets.getModule("command/CommandManager"),
@@ -33,14 +28,13 @@ define(function (require, exports, module) {
         ExtensionUtils = brackets.getModule("utils/ExtensionUtils"),
         WorkingSetView = brackets.getModule("project/WorkingSetView"),
         MainViewManager = brackets.getModule("view/MainViewManager"),
-        Menus           = brackets.getModule("command/Menus"),
-        RemoteFile      = require("RemoteFile");
+        Menus           = brackets.getModule("command/Menus");
 
     var HTTP_PROTOCOL = "http:",
         HTTPS_PROTOCOL = "https:";
-    
+
     ExtensionUtils.loadStyleSheet(module, "styles.css");
-    
+
     function protocolClassProvider(data) {
         if (data.fullPath.startsWith("http://")) {
             return "http";
@@ -49,41 +43,74 @@ define(function (require, exports, module) {
         if (data.fullPath.startsWith("https://")) {
             return "https";
         }
-        
+
         return "";
     }
-    
+
     /**
      * Disable context menus which are not useful for remote file
      */
     function _setMenuItemsVisible() {
         var file = MainViewManager.getCurrentlyViewedFile(MainViewManager.ACTIVE_PANE),
-            cMenuItems = [Commands.FILE_SAVE, Commands.FILE_RENAME, Commands.NAVIGATE_SHOW_IN_FILE_TREE, Commands.NAVIGATE_SHOW_IN_OS],
+            cMenuItems = [Commands.FILE_SAVE, Commands.FILE_RENAME, Commands.NAVIGATE_SHOW_IN_FILE_TREE],
             // Enable menu options when no file is present in active pane
             enable = !file || (file.constructor.name !== "RemoteFile");
-        
-            // Enable or disable commands based on whether the file is a remoteFile or not.
-            cMenuItems.forEach(function (item) {
-                CommandManager.get(item).setEnabled(enable);
-            });
+
+        // Enable or disable commands based on whether the file is a remoteFile or not.
+        cMenuItems.forEach(function (item) {
+            CommandManager.get(item).setEnabled(enable);
+        });
+    }
+
+    function _getGitHubRawURL(urlObject) {
+        let pathVector = urlObject.pathname.split("/");
+        let BLOB_STRING_LOCATION = 3;
+        if(pathVector.length>BLOB_STRING_LOCATION+1 && pathVector[BLOB_STRING_LOCATION] === "blob"){
+            // Github blob URL of the form https://github.com/brackets-cont/brackets/blob/master/.gitignore
+            // transform to https://raw.githubusercontent.com/brackets-cont/brackets/master/.gitignore
+            pathVector.splice(BLOB_STRING_LOCATION,1);
+            let newPath = pathVector.join("/");
+            return `https://raw.githubusercontent.com${newPath}`;
+        }
+
+        return urlObject.href;
+    }
+
+    function _getGitLabRawURL(urlObject) {
+        // Gitlab does not specify CORS, so this wont work in phoenix, but will work in brackets for now
+        let pathVector = urlObject.pathname.split("/");
+        let BLOB_STRING_LOCATION = 4;
+        if(pathVector.length>BLOB_STRING_LOCATION+1 && pathVector[BLOB_STRING_LOCATION] === "blob"){
+            // GitLab blob URL of the form https://gitlab.com/gitlab-org/gitlab-foss/-/blob/master/.codeclimate.yml
+            // transform to https://gitlab.com/gitlab-org/gitlab-foss/-/raw/master/.codeclimate.yml
+            pathVector[BLOB_STRING_LOCATION] = "raw";
+            let newPath = pathVector.join("/");
+            return `https://gitlab.com${newPath}`;
+        }
+
+        return urlObject.href;
+    }
+
+    /**
+     * Checks the URL to see if it is from known code URL sites(Eg. Github) and transforms
+     * it into URLs to fetch raw code.
+     * @param url
+     * @private
+     * @return code URL if transformed, else returns the arg URL as is
+     */
+    function _getRawURL(url) {
+        let urlObject = new URL(url);
+        switch (urlObject.hostname) {
+        case "github.com": return _getGitHubRawURL(urlObject);
+        case "gitlab.com": return _getGitLabRawURL(urlObject);
+        default: return url;
+        }
     }
 
     AppInit.htmlReady(function () {
-        
+
         Menus.getContextMenu(Menus.ContextMenuIds.WORKING_SET_CONTEXT_MENU).on("beforeContextMenuOpen", _setMenuItemsVisible);
         MainViewManager.on("currentFileChange", _setMenuItemsVisible);
-        
-        var protocolAdapter = {
-            priority: 0, // Default priority
-            fileImpl: RemoteFile,
-            canRead: function (filePath) {
-                return true; // Always claim true, we are the default adpaters
-            }
-        };
-
-        // Register the custom object as HTTP and HTTPS protocol adapter
-        FileSystem.registerProtocolAdapter(HTTP_PROTOCOL, protocolAdapter);
-        FileSystem.registerProtocolAdapter(HTTPS_PROTOCOL, protocolAdapter);
 
         // Register as quick open plugin for file URI's having HTTP:|HTTPS: protocol
         QuickOpen.addQuickOpenPlugin(
@@ -98,13 +125,14 @@ define(function (require, exports, module) {
                     return [HTTP_PROTOCOL, HTTPS_PROTOCOL].indexOf(protocol) !== -1;
                 },
                 itemFocus: function (query) {
-                }, // no op
+                    // no op
+                },
                 itemSelect: function () {
-                    CommandManager.execute(Commands.FILE_OPEN, {fullPath: arguments[0]});
+                    CommandManager.execute(Commands.FILE_OPEN, {fullPath: _getRawURL(arguments[0])});
                 }
             }
         );
-        
+
         WorkingSetView.addClassProvider(protocolClassProvider);
     });
 

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -1,12 +1,6 @@
 /*
- * Copyright (c) 2013 - present Adobe Systems Incorporated. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * Original work Copyright (c) 2013 - 2021 Adobe Systems Incorporated. All rights reserved.
  *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
@@ -93,6 +87,7 @@ define(function (require, exports, module) {
         File            = require("filesystem/File"),
         FileIndex       = require("filesystem/FileIndex"),
         FileSystemError = require("filesystem/FileSystemError"),
+        RemoteFile      = require("filesystem/RemoteFile"),
         WatchedRoot     = require("filesystem/WatchedRoot"),
         EventDispatcher = require("utils/EventDispatcher"),
         PathUtils       = require("thirdparty/path-utils/path-utils"),
@@ -633,9 +628,9 @@ define(function (require, exports, module) {
 
         if (protocolAdapter && protocolAdapter.fileImpl) {
             return new protocolAdapter.fileImpl(protocol, path, this);
-        } else {
-            return this._getEntryForPath(File, path);
         }
+        return this._getEntryForPath(File, path);
+
     };
 
     /**
@@ -1101,4 +1096,20 @@ define(function (require, exports, module) {
 
     // Initialize the singleton instance
     _instance.init(require("fileSystemImpl"));
+
+    // attach remote file handlers
+    var HTTP_PROTOCOL = "http:",
+        HTTPS_PROTOCOL = "https:";
+
+    var protocolAdapter = {
+        priority: 0, // Default priority
+        fileImpl: RemoteFile,
+        canRead: function (filePath) {
+            return true; // Always claim true, we are the default adpaters
+        }
+    };
+
+    // Register the custom object as HTTP and HTTPS protocol adapter
+    registerProtocolAdapter(HTTP_PROTOCOL, protocolAdapter);
+    registerProtocolAdapter(HTTPS_PROTOCOL, protocolAdapter);
 });

--- a/src/filesystem/RemoteFile.js
+++ b/src/filesystem/RemoteFile.js
@@ -1,12 +1,6 @@
 /*
- * Copyright (c) 2018 - present Adobe Systems Incorporated. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * Original work Copyright (c) 2018 - 2021 Adobe Systems Incorporated. All rights reserved.
  *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
@@ -21,18 +15,20 @@
  *
  */
 
+/*global Uint8Array, TextDecoder*/
+
 define(function (require, exports, module) {
     "use strict";
 
-    var FileSystemError = brackets.getModule("filesystem/FileSystemError"),
-        FileSystemStats = brackets.getModule("filesystem/FileSystemStats");
+    var FileSystemError = require("filesystem/FileSystemError"),
+        FileSystemStats = require("filesystem/FileSystemStats");
 
     var SESSION_START_TIME = new Date();
 
     /**
      * Create a new file stat. See the FileSystemStats class for more details.
      *
-     * @param {!string} fullPath The full path for this File.
+     * @param {!string} uri The full path for this File.
      * @return {FileSystemStats} stats.
      */
     function _getStats(uri) {
@@ -44,15 +40,15 @@ define(function (require, exports, module) {
             hash: uri
         });
     }
-    
+
     function _getFileName(filePath) {
         var fileName = filePath.split('/').pop();
-        
+
         if (!fileName.trim()) {
             fileName = filePath.trim().slice(0, -1);
             fileName = fileName.split('/').pop();
         }
-        
+
         return fileName;
     }
 
@@ -166,18 +162,43 @@ define(function (require, exports, module) {
         // no-op
     };
 
+    function _remoteRead(url, encoding, successCB, errorCB) {
+        let xmlhttp = new XMLHttpRequest();
+        xmlhttp.open("GET", url, true);
+        xmlhttp.responseType = "arraybuffer";
+
+        xmlhttp.onload = function(oEvent) {
+            var arrayBuffer = xmlhttp.response;
+
+            // if you want to access the bytes:
+            var byteArray = new Uint8Array(arrayBuffer);
+
+            try {
+                successCB(new TextDecoder(encoding).decode(byteArray));
+            } catch (err) {
+                errorCB(err);
+            }
+        };
+
+        xmlhttp.onerror = function (err) {
+            errorCB(err);
+        };
+        xmlhttp.send();
+    }
+
     /**
      * Reads a remote file.
      *
      * @param {Object=} options Currently unused.
-     * @param {function (?string, string=, FileSystemStats=)} callback Callback that is passed the
+     * @param {function (err?, ?string, string=, FileSystemStats=)} callback Callback that is passed the
      *              FileSystemError string or the file's contents and its stats.
      */
     RemoteFile.prototype.read = function (options, callback) {
         if (typeof (options) === "function") {
             callback = options;
+            options = {};
         }
-        this._encoding = "utf8";
+        this._encoding = options.encoding || "utf8";
 
         if (this._contents !== null && this._stat) {
             callback(null, this._contents, this._encoding, this._stat);
@@ -185,14 +206,10 @@ define(function (require, exports, module) {
         }
 
         var self = this;
-        $.ajax({
-            url: this.fullPath
-        })
-        .done(function (data) {
+        _remoteRead(this.fullPath, this._encoding, function (data) {
             self._contents = data;
             callback(null, data, self._encoding, self._stat);
-        })
-        .fail(function (e) {
+        }, function (e) {
             callback(FileSystemError.NOT_FOUND);
         });
     };


### PR DESCRIPTION
Ported in from phoenix

* Move remote file adapter to core Reading HTTP/HTTPS remote content as a file is a core requirement.
* Added support for file reads on any browser supported encoding from HTTP/HTTPS links
* GitHub and GitLab remote file link open using quick open

## phoenix changes
* https://github.com/phcode-dev/phoenix/pull/275
* https://github.com/phcode-dev/phoenix/pull/274

## Testing
* All remote file extension tests working.
* Verified ctrl_shift+o to open an http/s URL works.
