### PR TITLE
removing Linux mention from the download section

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ How to install and run Brackets
 -------------------------------
 #### Download
 
-Installers for the latest stable build for Mac, Windows and Linux (Debian/Ubuntu) can be [downloaded here](https://brackets-cont.github.io/).
+Installers for the latest stable build for Mac and Windows can be [downloaded here](https://brackets-cont.github.io/).
 
 #### Usage
 


### PR DESCRIPTION
removing Linux mention from the download section of the page as there is currently no Linux build. continuing to have that listed incorrectly could cause confusion.