### PR TITLE
fix: live preview not working on chrome v111

### DIFF
--- a/src/LiveDevelopment/Inspector/Inspector.js
+++ b/src/LiveDevelopment/Inspector/Inspector.js
@@ -330,7 +330,8 @@ define(function Inspector(require, exports, module) {
             var i, page;
             for (i in response) {
                 page = response[i];
-                if (page.webSocketDebuggerUrl && page.url.indexOf(url) === 0) {
+                if (page.webSocketDebuggerUrl &&
+                    (page.url.indexOf(url) === 0 || page.url.endsWith("/LiveDevelopment/launch.html"))) {
                     connect(page.webSocketDebuggerUrl);
                     // _connectDeferred may be resolved by onConnect or rejected by onError
                     return;

--- a/src/LiveDevelopment/MultiBrowserImpl/launchers/Launcher.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/launchers/Launcher.js
@@ -43,7 +43,12 @@ define(function (require, exports, module) {
         _nodeDomain.exec("launch", url);
     }
 
+    function launchChromeWithRDP(url) {
+        return _nodeDomain.exec("launchChromeWithRDP", url);
+    }
+
     // Exports
     exports.launch = launch;
+    exports.launchChromeWithRDP = launchChromeWithRDP;
 
 });

--- a/src/LiveDevelopment/MultiBrowserImpl/launchers/node/LauncherDomain.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/launchers/node/LauncherDomain.js
@@ -43,6 +43,18 @@ function _cmdLaunch(url) {
     open(url);
 }
 
+function _launchChromeWithRDP(url, enableRemoteDebugging) {
+    open(url, {app: ['chrome',
+            "--disk-cache-size=250000000",
+            "--no-first-run",
+            "--no-default-browser-check",
+            "--disable-default-apps",
+            "--allow-file-access-from-files",
+            "--remote-debugging-port=9222",
+            "--user-data-dir=%appdata%/lp",
+            "--remote-allow-origins=*"
+        ]});
+}
 
 /**
  * Initializes the domain and registers commands.
@@ -62,6 +74,19 @@ function init(domainManager) {
         [
             { name: "url", type: "string", description: "file:// url to the HTML file" },
             { name: "browser", type: "string", description: "browser name"}
+        ],
+        []
+    );
+
+    domainManager.registerCommand(
+        "launcher",      // domain name
+        "launchChromeWithRDP",       // command name
+        _launchChromeWithRDP,     // command handler function
+        false,          // this command is synchronous in Node
+        "Launches a given HTML file in the browser for live development",
+        [
+            { name: "url", type: "string", description: "file:// url to the HTML file" },
+            { name: "enableRemoteDebugging", type: "string", description: "enable remote debugging or not"}
         ],
         []
     );

--- a/src/utils/NativeApp.js
+++ b/src/utils/NativeApp.js
@@ -25,7 +25,8 @@ define(function (require, exports, module) {
     "use strict";
 
     var Async           = require("utils/Async"),
-        FileSystemError = require("filesystem/FileSystemError");
+        FileSystemError = require("filesystem/FileSystemError"),
+        DefaultLauncher = require("LiveDevelopment/MultiBrowserImpl/launchers/Launcher");
 
     /**
      * @private
@@ -45,25 +46,10 @@ define(function (require, exports, module) {
     /** openLiveBrowser
      * Open the given URL in the user's system browser, optionally enabling debugging.
      * @param {string} url The URL to open.
-     * @param {boolean=} enableRemoteDebugging Whether to turn on remote debugging. Default false.
      * @return {$.Promise}
      */
-    function openLiveBrowser(url, enableRemoteDebugging) {
-        var result = new $.Deferred();
-
-        brackets.app.openLiveBrowser(url, !!enableRemoteDebugging, function onRun(err, pid) {
-            if (!err) {
-                // Undefined ids never get removed from list, so don't push them on
-                if (pid !== undefined) {
-                    liveBrowserOpenedPIDs.push(pid);
-                }
-                result.resolve(pid);
-            } else {
-                result.reject(_browserErrToFileError(err));
-            }
-        });
-
-        return result.promise();
+    function openLiveBrowser(url) {
+        return DefaultLauncher.launchChromeWithRDP(url);
     }
 
     /** closeLiveBrowser


### PR DESCRIPTION
Fixes: https://github.com/brackets-cont/brackets/issues/262

Reason: Chrome added CORS header for the remote debug port used by live preview. We added the appropriate CORS header for the `file:///` URLs used by brackets which is `*` . This is a less secure implementation than the one phcode.dev uses, but as we will be moving to phcode.dev arch, this is a temporary fix.

 > This fix ports the browser launch code from its c++/native impl to pure node js bases js impl.

* Tested working in windows with chrome v111
* Tested Working in mac
